### PR TITLE
Add max age for access token

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,6 +45,7 @@ type Server struct {
 type TokenConfig struct {
 	TokenPath             string `env:"TOKEN_PATH" help:"Path to the token in the authentication response. Defaults to 'id_token'." default:"id_token"`
 	AccessTokenCookieName string `env:"ACCESS_TOKEN_COOKIE_NAME" help:"Name of the cookie to store the access token. Defaults to 'x-access-token'." default:"x-access-token"`
+	AccessTokenMaxAge     int    `env:"ACCESS_TOKEN_MAX_AGE" help:"Max age (in seconds) of the access token. Defaults to '3600'." default:"3600"`
 }
 
 // Oidc struct
@@ -114,6 +115,7 @@ func (r *Run) Run(_ *Globals, l *zap.SugaredLogger) error {
 		SleepBeforeRedirect:            r.SleepBeforeRedirect,
 		BasePath:                       basePath,
 		AccessTokenCookieName:          r.AccessTokenCookieName,
+		AccessTokenMaxAge:              r.AccessTokenMaxAge,
 		OrgAttributePath:               r.OrgAttributePath,
 		MappingConfigFile:              r.MappingConfigFile,
 		RoleAttributePath:              r.RoleAttributePath,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -105,6 +105,7 @@ func Callback(ctx echo.Context, cfg *config.Config, l *zap.SugaredLogger) error 
 	cookie := &http.Cookie{
 		Name:     cfg.AccessTokenCookieName,
 		Value:    oauth2Token.AccessToken,
+		MaxAge:   cfg.AccessTokenMaxAge,
 		HttpOnly: true,
 		Secure:   cfg.Secure,
 		Path:     "/",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	SleepBeforeRedirect            int
 	BasePath                       string
 	AccessTokenCookieName          string
+	AccessTokenMaxAge              int
 	OrgAttributePath               string
 	MappingConfigFile              string
 	RoleAttributePath              string
@@ -100,6 +101,7 @@ func (cfg *Config) LogConfig(l *zap.SugaredLogger) {
 	l.Infow("Token Configuration",
 		"TokenPath", cfg.TokenPath,
 		"AccessTokenCookieName", cfg.AccessTokenCookieName,
+		"AccessTokenMaxAge", cfg.AccessTokenMaxAge,
 	)
 	l.Infow("OIDC Configuration",
 		"ClientID", cfg.ClientID,


### PR DESCRIPTION
Add max age for token to ensure that session is expired when OIDC token is also expired.