### PR TITLE
Sort resolved mapping by role precedence

### DIFF
--- a/internal/grafana/api.go
+++ b/internal/grafana/api.go
@@ -56,6 +56,11 @@ func updateUserOrgRoles(loginOrEmail, host string, resolvedMappings []config.Org
 			if err != nil {
 				return err
 			}
+			// sync user orgs after granting role
+			userOrgs, err = getUserOrgs(userID, host, cfg)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/grafana/mapping_test.go
+++ b/internal/grafana/mapping_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gitlab.pnet.ch/observability/grafana/grafana-auth-reverse-proxy/internal/config"
 )
 
 func TestSearchJsonForAttr(t *testing.T) {
@@ -43,4 +44,15 @@ func TestSearchJsonForAttr(t *testing.T) {
 		})
 
 	}
+}
+
+func TestSortedResolvedMappings_SameOrg(t *testing.T) {
+	resolvedMappings := []config.OrgMapping{{Group: "admin_group", OrgID: 1, OrgRole: "Admin"}, {Group: "editor_group", OrgID: 1, OrgRole: "Editor"}}
+	SortResolvedMappings(resolvedMappings)
+	require.Equal(t, resolvedMappings, []config.OrgMapping{{Group: "editor_group", OrgID: 1, OrgRole: "Editor"}, {Group: "admin_group", OrgID: 1, OrgRole: "Admin"}})
+}
+func TestSortedResolvedMappings_ComplexOrgs(t *testing.T) {
+	resolvedMappings := []config.OrgMapping{{Group: "admin_group1", OrgID: 1, OrgRole: "Admin"}, {Group: "editor_group1", OrgID: 1, OrgRole: "Editor"}, {Group: "admin_group6", OrgID: 6, OrgRole: "Admin"}, {Group: "editor_group6", OrgID: 6, OrgRole: "Editor"}}
+	SortResolvedMappings(resolvedMappings)
+	require.Equal(t, resolvedMappings, []config.OrgMapping{{Group: "editor_group1", OrgID: 1, OrgRole: "Editor"}, {Group: "admin_group1", OrgID: 1, OrgRole: "Admin"}, {Group: "editor_group6", OrgID: 6, OrgRole: "Editor"}, {Group: "admin_group6", OrgID: 6, OrgRole: "Admin"}})
 }

--- a/testdata/mapping.yml
+++ b/testdata/mapping.yml
@@ -1,7 +1,7 @@
 org_mapping:
-    - group: manage-account
-      org_id: 1
-      org_role: Viewer
-    - group: create-realm
-      org_id: 2
-      org_role: Editor
+- group: manage-account
+  org_id: 1
+  org_role: Viewer
+- group: create-realm
+  org_id: 2
+  org_role: Editor


### PR DESCRIPTION
There may be multiple roles when it comes to different group mapping to the same grafana org.
This PR sort the precedence of role based on role importance and org id.